### PR TITLE
Update Gitea to 1.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [v1.0.4](https://github.com/fboulnois/gitea-docker/compare/v1.0.3...v1.0.4) - 2023-07-21
+
+### Added
+
+* Update gitea to 1.20.0
+
 ## [v1.0.3](https://github.com/fboulnois/gitea-docker/compare/v1.0.2...v1.0.3) - 2023-07-04
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN set -x \
 WORKDIR /srv
 
 # gitea build time args
-ARG GITEA_VERSION=1.19.4 \
+ARG GITEA_VERSION=1.20.0 \
   GITEA_DOWNLOAD=https://github.com/go-gitea/gitea/releases/download \
   GITEA_GPG_RECV=7C9E68152594688862D62AF62D9AE806EC1592E2
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Gitea on Docker
 
-Runs a minimal [Gitea](https://gitea.io) Docker deployment built on Debian 11.
+Runs a minimal [Gitea](https://gitea.io) Docker deployment built on Debian 12.
 
 ## Features
 
-* Built on Debian 11 for portability
+* Built on Debian 12 for portability
 * Uses a non-root user for security
 * Only runs `git` and `gitea` in the container
 * Simple `Dockerfile` and `docker-compose.yml` files


### PR DESCRIPTION
Update Gitea to [v1.20.0](https://github.com/go-gitea/gitea/releases/tag/v1.20.0) and also update the docs to use Debian 12.